### PR TITLE
Non-python version of operating-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ __pycache__
 
 # Go best practices dictate that libraries should not include the vendor directory
 vendor
+
+
+# Terraform Module artifacts
+os.txt

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The following modules are available:
 * [intermediate-variable](/modules/intermediate-variable): A simple module that returns as output the exact variables
   you pass to it as inputs. This gives you a way to store intermediate values that contain interpolations.
 * [join-path](/modules/join-path): This module can be used to join a list of given path parts into a single path that is
-  platform/operating system aware. **(This module requires Python)**
+  platform/operating system aware.
 * [operating-system](/modules/operating-system): This module can be used to figure out what operating system is being
-  used to run Terraform. **(This module requires Python)**
+  used to run Terraform.
 * [require-executable](/modules/require-executable): This is a module that can be used to ensure particular executables
   is available in the `PATH`. **(This module requires Python)**
 * [run-pex-as-data-source](/modules/run-pex-as-data-source): This module prepares a portable environment for running PEX

--- a/examples/operating-system/main.tf
+++ b/examples/operating-system/main.tf
@@ -4,3 +4,16 @@ module "os" {
   # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/operating-system?ref=v1.0.8"
   source = "../../modules/operating-system"
 }
+
+resource "null_resource" "check_escape_char" {
+  triggers {
+    time = "${timestamp()}"
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOF
+    echo ${module.os.sh_esc_char}
+      "${var.echo}"
+    EOF
+  }
+}

--- a/examples/operating-system/variables.tf
+++ b/examples/operating-system/variables.tf
@@ -1,0 +1,4 @@
+variable "echo" {
+  description = "This will be echo'd out, using the shell escape character."
+  default     = "Hello, World"
+}

--- a/modules/join-path/README.md
+++ b/modules/join-path/README.md
@@ -1,10 +1,8 @@
 # Join Path Module
 
-This is a module that can be used to join a list of given path parts (that is, file and folder names) into a single 
+This is a module that can be used to join a list of given path parts (that is, file and folder names) into a single
 path with the appropriate path separator (backslash or forward slash) for the current operating system. This is useful
 for ensuring the paths you build will work properly on Windows, Linux, and OS X.
-
-This module uses Python under the hood so, the Python must be installed on the OS. 
 
 
 
@@ -19,21 +17,20 @@ See the [join-path example](/examples/join-path) for working sample code.
 ## Usage
 
 Simply use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
-page](https://github.com/gruntwork-io/package-terraform-utilities/releases), and specifying the path parts using the 
+page](https://github.com/gruntwork-io/package-terraform-utilities/releases), and specifying the path parts using the
 `path_parts` input:
 
 ```hcl
 module "path" {
   source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/join-path?ref=<VERSION>"
-  
+
   path_parts = ["foo", "bar", "baz.txt"]
 }
 ```
 
 You can now get the joined path using the `path` output:
-  
+
 ```hcl
 # Will be set to "foo/bar/baz.txt" on Linux and OS X, "foo\bar\baz.txt" on Windows
-joined_path = "${module.path.path}" 
+joined_path = "${module.path.path}"
 ```
-  

--- a/modules/operating-system/README.md
+++ b/modules/operating-system/README.md
@@ -1,10 +1,8 @@
 # Operating System Module
 
 This is a module that can be used to figure out what operating system is being used to run Terraform. This may be used
-to modify Terraform's behavior depending on the OS, such as modifying the way you format file paths on Linux vs 
-Windows (see also the [join-path module](/modules/join-path)). 
-
-This module uses Python under the hood so, the Python must be installed on the OS. 
+to modify Terraform's behavior depending on the OS, such as modifying the way you format file paths on Linux vs
+Windows (see also the [join-path module](/modules/join-path)).
 
 
 
@@ -27,14 +25,17 @@ module "os" {
 }
 ```
 
-* You can now get the name of the operating system from the `name` output, which will be set to either `Linux`, 
+* You can now get the name of the operating system from the `name` output, which will be set to either `Linux`,
   `Darwin`, or `Windows`
 
 * You can also get the path separator for the current OS—backslash for Windows, forward slash everywhere else—from the
   `path_separator` output.
-  
+
+* You can also get the escape character for the default shell of the platform. This is \` for Windows (CMD), and \\ for
+  other platforms.
+
 ```hcl
 operating_system_name = "${module.os.name}"
 path_separator        = "${module.os.path_separator}"
+sh_esc_char           = "${module.os.sh_esc_char}"
 ```
-  

--- a/modules/operating-system/main.tf
+++ b/modules/operating-system/main.tf
@@ -1,3 +1,34 @@
-data "external" "os" {
-  program = ["python", "-c", "import platform; print(\"{\\\"platform\\\": \\\"%s\\\"}\" % platform.system())"]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# DETERMINE OPERATING SYSTEM
+# This terraform module uses a set of known shell commands run via local-exec provisioners that only work on specific
+# platforms to determine the Operating System. In this way, only the one that works on the relevant platform will run
+# without error and write the platform information to a known file. This is then read out and passed on as outputs from
+# the module.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+resource "null_resource" "get_os" {
+  triggers {
+    time = "${timestamp()}"
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"$(uname)\" > ${path.module}/os.txt"
+
+    interpreter = ["sh", "-c"]
+
+    on_failure = "continue"
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"$([environment]::OSVersion.Platform)\" > ${path.module}/os.txt"
+
+    interpreter = ["PowerShell", "-Command"]
+
+    on_failure = "continue"
+  }
+}
+
+data "local_file" "os" {
+  filename   = "${path.module}/os.txt"
+  depends_on = ["null_resource.get_os"]
 }

--- a/modules/operating-system/outputs.tf
+++ b/modules/operating-system/outputs.tf
@@ -1,7 +1,27 @@
 output "name" {
-  value = "${data.external.os.result.platform}"
+  description = "The name of the OS platform. Will be one of Windows, Darwin, Linux. All other platforms are not supported."
+
+  # Use Windows for windows platforms for backwards compatibility
+  value = "${local.platform_name}"
 }
 
 output "path_separator" {
-  value = "${data.external.os.result.platform == "Windows" ? "\\" : "/"}"
+  description = "The separator character for paths on the platform."
+  value       = "${local.platform_name == "Windows" ? "\\" : "/"}"
+}
+
+output "sh_esc_char" {
+  description = "The escape character to use for the default shell on the platform (`sh` for Unix systems, `cmd` for Windows)."
+  value       = "${local.platform_name == "Windows" ? "`" : "\\"}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OUTPUT COMPUTATIONS
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_name = "${local.maybe_platform == "Win32NT" ? "Windows" : local.maybe_platform}"
+
+  # On destroy, the data source doesn't exist, so we need to use splat to handle that corner case.
+  maybe_platform = "${element(concat(data.local_file.os.*.content, list("")), 0)}"
 }

--- a/test/operating_system_test.go
+++ b/test/operating_system_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
 	"runtime"
 	"strings"
 	"testing"
@@ -10,11 +12,14 @@ import (
 func TestOperatingSystem(t *testing.T) {
 	t.Parallel()
 
+	uniqueID := random.UniqueId()
 	terratestOptions := createBaseTerratestOptions(t, "../examples/operating-system")
+	terratestOptions.Vars = map[string]interface{}{"echo": uniqueID}
 	defer terraform.Destroy(t, terratestOptions)
 
-	terraform.InitAndApply(t, terratestOptions)
+	out := terraform.InitAndApply(t, terratestOptions)
 
 	assertOutputEquals(t, "os_name", strings.Title(runtime.GOOS), terratestOptions)
 	assertOutputEquals(t, "path_separator", "/", terratestOptions)
+	assert.Contains(t, out, uniqueID)
 }


### PR DESCRIPTION
This implements the version of `operating-system` that we came up with a couple weeks ago that doesn't depend on python being installed. This is nice, as it removes one less dependency for some of the modules (e.g the `terraform-kubernetes-helm` repo).