### PR TITLE
Support triggers and environment variables for pex null_resource

### DIFF
--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -15,6 +15,8 @@ module "pex_resource" {
   # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/run-pex-as-resource?ref=v1.0.8"
   source = "../../modules/run-pex-as-resource"
 
+  triggers = var.triggers
+
   # Path components to each of the PEX binary
   python2_pex_path_parts = [
     path.module,

--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -40,6 +40,10 @@ module "pex_resource" {
 
   # The entrypoint of the sample_python_script, encoded as MODULE:FUNCTION
   script_main_function = "sample_python_script.main:main"
+
+  env = {
+    PEX_TEST_ENV = var.echo_string
+  }
 }
 
 # Run the PEX binary as a data source.

--- a/examples/pex/sample-python-script/sample_python_script/main.py
+++ b/examples/pex/sample-python-script/sample_python_script/main.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 import click
 import json
 import sys
@@ -17,6 +18,7 @@ def main(is_data):
     else:
         print("python version: {}".format(sys.version_info))
         print("This was successfully run as a local-exec provisioner")
+        print("Environment variable: {}".format(os.environ.get("PEX_TEST_ENV", None)))
 
 
 if __name__ == "__main__":

--- a/examples/pex/variables.tf
+++ b/examples/pex/variables.tf
@@ -3,3 +3,9 @@ variable "echo_string" {
   type        = string
   default     = "Hello world!"
 }
+
+variable "triggers" {
+  description = "Triggers for the pex null resource to rerun."
+  type        = map(string)
+  default     = null
+}

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -16,6 +16,8 @@ module "pex_env" {
 }
 
 resource "null_resource" "run_pex" {
+  triggers = var.triggers
+
   provisioner "local-exec" {
     command = "python ${module.pex_env.pex_path} ${module.pex_env.entrypoint_path} ${var.script_main_function} ${var.command_args}"
 

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -21,8 +21,11 @@ resource "null_resource" "run_pex" {
   provisioner "local-exec" {
     command = "python ${module.pex_env.pex_path} ${module.pex_env.entrypoint_path} ${var.script_main_function} ${var.command_args}"
 
-    environment = {
-      PYTHONPATH = module.pex_env.python_path
-    }
+    environment = merge(
+      {
+        PYTHONPATH = module.pex_env.python_path
+      },
+      var.env,
+    )
   }
 }

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -31,3 +31,9 @@ variable "command_args" {
   # We don't use null here because this is interpolated into the python script.
   default = ""
 }
+
+variable "triggers" {
+  description = "A map of arbitrary strings that, when changed, will force the null resource to be replaced, re-running any associated provisioners."
+  type        = map(string)
+  default     = null
+}

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -37,3 +37,9 @@ variable "triggers" {
   type        = map(string)
   default     = null
 }
+
+variable "env" {
+  description = "Additional environment variables to set for the command."
+  type        = map(string)
+  default     = {}
+}

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -214,7 +214,7 @@
   version = "v0.4.2"
 
 [[projects]]
-  digest = "1:653bb665ede505dfaa7345261d8208c9ee8cc5bdbe7e258110ae9807eb34dace"
+  digest = "1:be266d630ec373514070956a758ef11814e2ccec3245693f96fdfeeafa0a66cf"
   name = "github.com/gruntwork-io/terratest"
   packages = [
     "modules/aws",
@@ -233,8 +233,8 @@
     "modules/test-structure",
   ]
   pruneopts = ""
-  revision = "892abb2c35878d0808101bbfe6559e931dc2d354"
-  version = "v0.16.0"
+  revision = "495f4a90acde629ffcac17f75d308c8273c34646"
+  version = "v0.18.6"
 
 [[projects]]
   digest = "1:31bfd110d31505e9ffbc9478e31773bf05bf02adcaeb9b139af42684f9294c13"
@@ -490,8 +490,7 @@
   version = "v2.2.2"
 
 [[projects]]
-  branch = "release-1.12"
-  digest = "1:3e3e9df293bd6f9fd64effc9fa1f0edcd97e6c74145cd9ab05d35719004dc41f"
+  digest = "1:bd9c8b7155b31a5b8f420169a470d47aae7f5c9e4e6c5c18bb15bcdbd1c51bfd"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -527,7 +526,7 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "6db15a15d2d3874a6c3ddb2140ac9f3bc7058428"
+  revision = "a33c8200050fc0751848276811abf3fc029b3133"
 
 [[projects]]
   branch = "release-1.12"
@@ -645,12 +644,12 @@
   revision = "b6aa6aafe32b0767f075245e5d391381c5449c8a"
 
 [[projects]]
-  digest = "1:30b201b810685671ff5b26a02f9d8a520cea5b451790ffe13f15c26170ff27fb"
+  digest = "1:bb5d4c0decfc9aafe39a2f5eff7a7d692dd2f8a1af24712e7ea3d72356194587"
   name = "k8s.io/kubernetes"
   packages = ["pkg/kubectl/generate"]
   pruneopts = ""
-  revision = "66049e3b21efe110454d67df4fa62b08ea79a19b"
-  version = "v1.14.2"
+  revision = "2d3c76f9091b6bec110a5e63777c332469e0cba2"
+  version = "v1.15.3"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.16.0"
+  version = "0.18.6"

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -22,9 +24,10 @@ func TestRunPex(t *testing.T) {
 		"echo_string": expectedFoo,
 	}
 
-	terraform.InitAndApply(t, terratestOptions)
+	output := terraform.InitAndApply(t, terratestOptions)
 
 	assertOutputEquals(t, "command_echo", expectedFoo, terratestOptions)
+	strings.Contains(output, fmt.Sprintf("Environment variable: %s", expectedFoo))
 }
 
 func TestRunPexTriggers(t *testing.T) {

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -20,4 +21,32 @@ func TestRunPex(t *testing.T) {
 	terraform.InitAndApply(t, terratestOptions)
 
 	assertOutputEquals(t, "command_echo", expectedFoo, terratestOptions)
+}
+
+func TestRunPexTriggers(t *testing.T) {
+	t.Parallel()
+
+	terratestOptions := createBaseTerratestOptions(t, "../examples/pex")
+	defer terraform.Destroy(t, terratestOptions)
+
+	expectedFoo := random.UniqueId()
+	terratestOptions.Vars = map[string]interface{}{
+		"echo_string": expectedFoo,
+		"triggers": map[string]string{
+			"id": expectedFoo,
+		},
+	}
+
+	terraform.InitAndApply(t, terratestOptions)
+
+	assertOutputEquals(t, "command_echo", expectedFoo, terratestOptions)
+
+	// Assert that there is no diff
+	exitCode := terraform.PlanExitCode(t, terratestOptions)
+	assert.Equal(t, exitCode, 0)
+
+	// Now modify the trigger and verify the null_resource is recreated
+	terratestOptions.Vars["triggers"].(map[string]string)["id"] = random.UniqueId()
+	exitCode = terraform.PlanExitCode(t, terratestOptions)
+	assert.NotEqual(t, exitCode, 0)
 }

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -1,16 +1,20 @@
 package test
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRunPex(t *testing.T) {
 	t.Parallel()
 
-	terratestOptions := createBaseTerratestOptions(t, "../examples/pex")
+	testFolder := test_structure.CopyTerraformFolderToTemp(t, "..", "examples")
+	terratestOptions := createBaseTerratestOptions(t, filepath.Join(testFolder, "pex"))
 	defer terraform.Destroy(t, terratestOptions)
 
 	expectedFoo := random.UniqueId()
@@ -26,7 +30,8 @@ func TestRunPex(t *testing.T) {
 func TestRunPexTriggers(t *testing.T) {
 	t.Parallel()
 
-	terratestOptions := createBaseTerratestOptions(t, "../examples/pex")
+	testFolder := test_structure.CopyTerraformFolderToTemp(t, "..", "examples")
+	terratestOptions := createBaseTerratestOptions(t, filepath.Join(testFolder, "pex"))
 	defer terraform.Destroy(t, terratestOptions)
 
 	expectedFoo := random.UniqueId()


### PR DESCRIPTION
This adds support for the `triggers` attribute on the `null_resource` provisioned using `run-pex-as-resource`.

Additionally, this adds support for setting environment variables for the null resource provisioner command.