### PR TITLE
Support conditionally running the pex scripts

### DIFF
--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -42,7 +42,7 @@ module "pex_resource" {
   script_main_function = "sample_python_script.main:main"
 
   env = {
-    PEX_TEST_ENV = var.echo_string
+    RUN_PEX_TEST_ENV = var.echo_string
   }
 
   enabled = var.enabled
@@ -89,4 +89,3 @@ module "pex_data" {
 
   enabled = var.enabled
 }
-

--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -44,6 +44,8 @@ module "pex_resource" {
   env = {
     PEX_TEST_ENV = var.echo_string
   }
+
+  enabled = var.enabled
 }
 
 # Run the PEX binary as a data source.
@@ -84,5 +86,7 @@ module "pex_data" {
   command_query = {
     "echo" = var.echo_string
   }
+
+  enabled = var.enabled
 }
 

--- a/examples/pex/outputs.tf
+++ b/examples/pex/outputs.tf
@@ -1,9 +1,9 @@
 output "command_echo" {
   description = "For the pex data source, if successful, this will contain the echo string."
-  value       = module.pex_data.result["echo"]
+  value       = module.pex_data.result != null ? module.pex_data.result["echo"] : null
 }
 
 output "command_python_version" {
   description = "Read out the python version that was used to run the PEX"
-  value       = module.pex_data.result["python_version_info"]
+  value       = module.pex_data.result != null ? module.pex_data.result["python_version_info"] : null
 }

--- a/examples/pex/sample-python-script/sample_python_script/main.py
+++ b/examples/pex/sample-python-script/sample_python_script/main.py
@@ -18,7 +18,7 @@ def main(is_data):
     else:
         print("python version: {}".format(sys.version_info))
         print("This was successfully run as a local-exec provisioner")
-        print("Environment variable: {}".format(os.environ.get("PEX_TEST_ENV", None)))
+        print("Environment variable: {}".format(os.environ.get("RUN_PEX_TEST_ENV", None)))
 
 
 if __name__ == "__main__":

--- a/examples/pex/variables.tf
+++ b/examples/pex/variables.tf
@@ -9,3 +9,12 @@ variable "triggers" {
   type        = map(string)
   default     = null
 }
+
+# These variables are only used for testing purposes and should not be touched in normal operations, unless you know
+# what you are doing.
+
+variable "enabled" {
+  description = "Whether or not to run the PEX scripts."
+  type        = bool
+  default     = true
+}

--- a/modules/run-pex-as-data-source/main.tf
+++ b/modules/run-pex-as-data-source/main.tf
@@ -17,6 +17,8 @@ module "pex_env" {
 }
 
 data "external" "pex" {
+  count = var.enabled ? 1 : 0
+
   program = [
     "python",
     "-c",

--- a/modules/run-pex-as-data-source/outputs.tf
+++ b/modules/run-pex-as-data-source/outputs.tf
@@ -1,4 +1,4 @@
 output "result" {
   description = "Data source result of executing the PEX binary."
-  value       = data.external.pex.result
+  value       = concat(data.external.pex.*.result, [null])[0]
 }

--- a/modules/run-pex-as-data-source/variables.tf
+++ b/modules/run-pex-as-data-source/variables.tf
@@ -37,3 +37,9 @@ variable "command_query" {
   type        = map(string)
   default     = {}
 }
+
+variable "enabled" {
+  description = "If you set this variable to false, this module will not run the PEX script. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally enable the data source within this module. Note that when false, the output will be null."
+  type        = bool
+  default     = true
+}

--- a/modules/run-pex-as-data-source/variables.tf
+++ b/modules/run-pex-as-data-source/variables.tf
@@ -39,7 +39,7 @@ variable "command_query" {
 }
 
 variable "enabled" {
-  description = "If you set this variable to false, this module will not run the PEX script. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally enable the data source within this module. Note that when false, the output will be null."
+  description = "If you set this variable to false, this module will not run the PEX script. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally enable the data source within this module. Note that when false, the 'result' output will be null."
   type        = bool
   default     = true
 }

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -16,6 +16,8 @@ module "pex_env" {
 }
 
 resource "null_resource" "run_pex" {
+  count = var.enabled ? 1 : 0
+
   triggers = var.triggers
 
   provisioner "local-exec" {

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -43,3 +43,9 @@ variable "env" {
   type        = map(string)
   default     = {}
 }
+
+variable "enabled" {
+  description = "If you set this variable to false, this module will not run the PEX script. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally enable the null_resource within this module."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This adds support for conditionally running the PEX scripts so that they can be disabled with feature flags if people do not want to use them (for dependency management reasons).