### PR TITLE
Destroy provisioner

### DIFF
--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -45,6 +45,9 @@ module "pex_resource" {
     RUN_PEX_TEST_ENV = var.echo_string
   }
 
+  enable_delete_provisioner = true
+  delete_command_args       = "--is-delete"
+
   enabled = var.enabled
 }
 

--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -47,6 +47,8 @@ module "pex_resource" {
 
   enable_destroy_provisioner = true
   destroy_command_args       = "--is-delete"
+  pass_in_previous_triggers  = true
+  previous_trigger_option    = "--triggers-json"
 
   enabled = var.enabled
 }

--- a/examples/pex/main.tf
+++ b/examples/pex/main.tf
@@ -45,8 +45,8 @@ module "pex_resource" {
     RUN_PEX_TEST_ENV = var.echo_string
   }
 
-  enable_delete_provisioner = true
-  delete_command_args       = "--is-delete"
+  enable_destroy_provisioner = true
+  destroy_command_args       = "--is-delete"
 
   enabled = var.enabled
 }

--- a/examples/pex/sample-python-script/sample_python_script/main.py
+++ b/examples/pex/sample-python-script/sample_python_script/main.py
@@ -7,14 +7,23 @@ import sys
 
 @click.command()
 @click.option("--is-data/--no-is-data", default=False, help="Whether or not this is run as a data source")
-def main(is_data):
+@click.option("--is-delete/--no-is-delete", default=False, help="Whether or not this is run as a delete provisioner")
+def main(is_data, is_delete):
     if is_data:
         query = json.loads(sys.stdin.read())
-        print(json.dumps({
-            "echo": query.get("echo", ""),
-            "out": "This was successfully run as data source.",
-            "python_version_info": str(sys.version_info),
-        }))
+        print(
+            json.dumps(
+                {
+                    "echo": query.get("echo", ""),
+                    "out": "This was successfully run as data source.",
+                    "python_version_info": str(sys.version_info),
+                }
+            )
+        )
+    elif is_delete:
+        print("python version: {}".format(sys.version_info))
+        print("This was successfully run as a ___DELETE___ local-exec provisioner")
+        print("Environment variable: {}".format(os.environ.get("RUN_PEX_TEST_ENV", None)))
     else:
         print("python version: {}".format(sys.version_info))
         print("This was successfully run as a local-exec provisioner")

--- a/examples/pex/sample-python-script/sample_python_script/main.py
+++ b/examples/pex/sample-python-script/sample_python_script/main.py
@@ -8,7 +8,8 @@ import sys
 @click.command()
 @click.option("--is-data/--no-is-data", default=False, help="Whether or not this is run as a data source")
 @click.option("--is-delete/--no-is-delete", default=False, help="Whether or not this is run as a delete provisioner")
-def main(is_data, is_delete):
+@click.option("--triggers-json", help="JSON encoded triggers for the resource")
+def main(is_data, is_delete, triggers_json):
     if is_data:
         query = json.loads(sys.stdin.read())
         print(
@@ -17,6 +18,7 @@ def main(is_data, is_delete):
                     "echo": query.get("echo", ""),
                     "out": "This was successfully run as data source.",
                     "python_version_info": str(sys.version_info),
+                    "triggers": triggers_json,
                 }
             )
         )
@@ -24,10 +26,12 @@ def main(is_data, is_delete):
         print("python version: {}".format(sys.version_info))
         print("This was successfully run as a ___DELETE___ local-exec provisioner")
         print("Environment variable: {}".format(os.environ.get("RUN_PEX_TEST_ENV", None)))
+        print("Triggers: {}".format(triggers_json))
     else:
         print("python version: {}".format(sys.version_info))
         print("This was successfully run as a local-exec provisioner")
         print("Environment variable: {}".format(os.environ.get("RUN_PEX_TEST_ENV", None)))
+        print("Triggers: {}".format(triggers_json))
 
 
 if __name__ == "__main__":

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "run_pex" {
     command = (
       var.enable_destroy_provisioner
       # NOTE: The nested string interpolation can not be extracted because of the reference to self.
-      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} '${jsonencode(self.triggers)}'" : ""}"
+      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} '${jsonencode(self.triggers != null ? self.triggers : {})}'" : ""}"
       : "echo 'Skipping delete provisioner'"
     )
     environment = merge(

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -21,8 +21,7 @@ resource "null_resource" "run_pex" {
   triggers = var.triggers
 
   provisioner "local-exec" {
-    command = "python ${module.pex_env.pex_path} ${module.pex_env.entrypoint_path} ${var.script_main_function} ${var.command_args}"
-
+    command = "${local.python_call} ${var.command_args}"
     environment = merge(
       {
         PYTHONPATH = module.pex_env.python_path
@@ -30,4 +29,23 @@ resource "null_resource" "run_pex" {
       var.env,
     )
   }
+
+  provisioner "local-exec" {
+    when = destroy
+    command = (
+      var.enable_delete_provisioner
+      ? "${local.python_call} ${var.delete_command_args}"
+      : "echo 'Skipping delete provisioner'"
+    )
+    environment = merge(
+      {
+        PYTHONPATH = module.pex_env.python_path
+      },
+      var.env,
+    )
+  }
+}
+
+locals {
+  python_call = "python ${module.pex_env.pex_path} ${module.pex_env.entrypoint_path} ${var.script_main_function}"
 }

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -33,8 +33,8 @@ resource "null_resource" "run_pex" {
   provisioner "local-exec" {
     when = destroy
     command = (
-      var.enable_delete_provisioner
-      ? "${local.python_call} ${var.delete_command_args}"
+      var.enable_destroy_provisioner
+      ? "${local.python_call} ${var.destroy_command_args}"
       : "echo 'Skipping delete provisioner'"
     )
     environment = merge(

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -35,7 +35,7 @@ resource "null_resource" "run_pex" {
     command = (
       var.enable_destroy_provisioner
       # NOTE: The nested string interpolation can not be extracted because of the reference to self.
-      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} ${jsonencode(self.triggers)}" : ""}"
+      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} '${jsonencode(self.triggers)}'" : ""}"
       : "echo 'Skipping delete provisioner'"
     )
     environment = merge(

--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -34,7 +34,8 @@ resource "null_resource" "run_pex" {
     when = destroy
     command = (
       var.enable_destroy_provisioner
-      ? "${local.python_call} ${var.destroy_command_args}"
+      # NOTE: The nested string interpolation can not be extracted because of the reference to self.
+      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} ${jsonencode(self.triggers)}" : ""}"
       : "echo 'Skipping delete provisioner'"
     )
     environment = merge(

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -32,7 +32,7 @@ variable "command_args" {
   default = ""
 }
 
-variable "delete_command_args" {
+variable "destroy_command_args" {
   description = "The arguments to pass to the command as a string on delete"
   type        = string
 
@@ -58,8 +58,8 @@ variable "enabled" {
   default     = true
 }
 
-variable "enable_delete_provisioner" {
-  description = "If you set this variable to true, the same command will be called on delete with the args specified in delete_command_args."
+variable "enable_destroy_provisioner" {
+  description = "If you set this variable to true, the same command will be called on destroy with the args specified in destroy_command_args."
   type        = bool
   default     = false
 }

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -32,6 +32,14 @@ variable "command_args" {
   default = ""
 }
 
+variable "delete_command_args" {
+  description = "The arguments to pass to the command as a string on delete"
+  type        = string
+
+  # We don't use null here because this is interpolated into the python script.
+  default = ""
+}
+
 variable "triggers" {
   description = "A map of arbitrary strings that, when changed, will force the null resource to be replaced, re-running any associated provisioners."
   type        = map(string)
@@ -48,4 +56,10 @@ variable "enabled" {
   description = "If you set this variable to false, this module will not run the PEX script. This is used as a workaround because Terraform does not allow you to use the 'count' parameter on modules. By using this parameter, you can optionally enable the null_resource within this module."
   type        = bool
   default     = true
+}
+
+variable "enable_delete_provisioner" {
+  description = "If you set this variable to true, the same command will be called on delete with the args specified in delete_command_args."
+  type        = bool
+  default     = false
 }

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -63,3 +63,15 @@ variable "enable_destroy_provisioner" {
   type        = bool
   default     = false
 }
+
+variable "pass_in_previous_triggers" {
+  description = "If you set this variable to true, this module will pass in the json encoded triggers that were used when the resource was created, prefixed by var.previous_trigger_option."
+  type        = bool
+  default     = false
+}
+
+variable "previous_trigger_option" {
+  description = "Prefix the json encoded trigger with this string prior to passing into the command."
+  type        = string
+  default     = ""
+}

--- a/modules/run-pex-as-resource/variables.tf
+++ b/modules/run-pex-as-resource/variables.tf
@@ -65,13 +65,13 @@ variable "enable_destroy_provisioner" {
 }
 
 variable "pass_in_previous_triggers" {
-  description = "If you set this variable to true, this module will pass in the json encoded triggers that were used when the resource was created, prefixed by var.previous_trigger_option."
+  description = "If you set this variable to true, this module will pass in the json encoded triggers that were used when the resource was created. If the script expects option args, use var.previous_trigger_option to set which option to pass the triggers json as."
   type        = bool
   default     = false
 }
 
 variable "previous_trigger_option" {
-  description = "Prefix the json encoded trigger with this string prior to passing into the command."
+  description = "Pass in the json encoded trigger with this string as the option to passing into the command. E.g, setting this to `--triggers` will pass in the option `--triggers TRIGGERS_JSON`."
   type        = string
   default     = ""
 }

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,10 @@ func TestRunPex(t *testing.T) {
 
 	testFolder := test_structure.CopyTerraformFolderToTemp(t, "..", "examples")
 	terratestOptions := createBaseTerratestOptions(t, filepath.Join(testFolder, "pex"))
-	defer terraform.Destroy(t, terratestOptions)
+	defer func() {
+		destroyOut := terraform.Destroy(t, terratestOptions)
+		assert.Contains(t, destroyOut, "___DELETE___")
+	}()
 
 	expectedFoo := random.UniqueId()
 	terratestOptions.Vars = map[string]interface{}{

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -37,9 +37,15 @@ func TestRunPexTriggers(t *testing.T) {
 
 	testFolder := test_structure.CopyTerraformFolderToTemp(t, "..", "examples")
 	terratestOptions := createBaseTerratestOptions(t, filepath.Join(testFolder, "pex"))
-	defer terraform.Destroy(t, terratestOptions)
-
 	expectedFoo := random.UniqueId()
+
+	defer func() {
+		delete(terratestOptions.Vars, "triggers")
+		destroyOut := terraform.Destroy(t, terratestOptions)
+		assert.Contains(t, destroyOut, "___DELETE___")
+		assert.Contains(t, destroyOut, expectedFoo)
+	}()
+
 	terratestOptions.Vars = map[string]interface{}{
 		"echo_string": expectedFoo,
 		"triggers": map[string]string{

--- a/test/pex_test.go
+++ b/test/pex_test.go
@@ -40,7 +40,10 @@ func TestRunPexTriggers(t *testing.T) {
 	expectedFoo := random.UniqueId()
 
 	defer func() {
+		// Remove triggers from the passed in vars to ensure the unique string is not passed in on destroy. This way, we
+		// can validate that the triggers option is indeed coming from the triggers stored in the state file.
 		delete(terratestOptions.Vars, "triggers")
+
 		destroyOut := terraform.Destroy(t, terratestOptions)
 		assert.Contains(t, destroyOut, "___DELETE___")
 		assert.Contains(t, destroyOut, expectedFoo)


### PR DESCRIPTION
This PR introduces the ability to setup a destroy provisioner for the `run-pex-as-resource` module, so that you can run the same pex in cleanup mode on destroy.