### PR TITLE
Workaround for restrictions in destroy time provisioners

### DIFF
--- a/modules/run-pex-as-resource/main.tf
+++ b/modules/run-pex-as-resource/main.tf
@@ -18,7 +18,24 @@ module "pex_env" {
 resource "null_resource" "run_pex" {
   count = var.enabled ? 1 : 0
 
-  triggers = var.triggers
+  triggers = merge(
+    var.triggers != null ? var.triggers : {},
+
+    # We store various values in the triggers so that they can be used in the destroy time provisioner.
+    # See https://github.com/hashicorp/terraform/issues/23679 for more details.
+    {
+      __pythonpath = module.pex_env.python_path
+      __env        = jsonencode(var.env)
+      __destroy_provisioner_command_args = (
+        var.enable_destroy_provisioner
+        # NOTE: The nested string interpolation can not be extracted because of the reference to self.
+        ? "${local.python_call} ${var.destroy_command_args}"
+        : "echo 'Skipping delete provisioner'"
+      )
+      __destroy_provisioner_pass_in_previous_triggers = var.pass_in_previous_triggers ? "true" : "false"
+      __destroy_provisioner_previous_trigger_option   = var.previous_trigger_option
+    },
+  )
 
   provisioner "local-exec" {
     command = "${local.python_call} ${var.command_args}"
@@ -32,17 +49,22 @@ resource "null_resource" "run_pex" {
 
   provisioner "local-exec" {
     when = destroy
-    command = (
-      var.enable_destroy_provisioner
-      # NOTE: The nested string interpolation can not be extracted because of the reference to self.
-      ? "${local.python_call} ${var.destroy_command_args} ${var.pass_in_previous_triggers ? "${var.previous_trigger_option} '${jsonencode(self.triggers != null ? self.triggers : {})}'" : ""}"
-      : "echo 'Skipping delete provisioner'"
+    command = join(
+      " ",
+      [
+        self.triggers.__destroy_provisioner_command_args,
+        (
+          self.triggers.__destroy_provisioner_pass_in_previous_triggers == "true"
+          ? "${self.triggers.__destroy_provisioner_previous_trigger_option} '${jsonencode(self.triggers != null ? self.triggers : {})}'"
+          : ""
+        )
+      ]
     )
     environment = merge(
       {
-        PYTHONPATH = module.pex_env.python_path
+        PYTHONPATH = self.triggers.__pythonpath
       },
-      var.env,
+      jsondecode(self.triggers.__env),
     )
   }
 }


### PR DESCRIPTION
This works around https://github.com/hashicorp/terraform/issues/23679, which will very soon become errors (I believe in the next patch release) by storing all the values in triggers. This breaks intuition in most cases and could potentially lead to a whole bunch of gotchas, but I don't see how else we can continue doing this.