### PR TITLE
New module: executable-dependency

### DIFF
--- a/examples/executable-dependency/README.md
+++ b/examples/executable-dependency/README.md
@@ -1,0 +1,21 @@
+# Executable dependency example
+
+This folder shows examples of how to use the [executable-dependency module](/modules/executable-dependency) to check if 
+an executable is already installed, and if it's not, download it from a URL. This example will then run this executable
+to prove that it was installed correctly. 
+
+The executable to run, the args to pass to it, and the download URL are all configurable in `variables.tf`. The default
+values show an example of ensuring the [kubergrunt](https://github.com/gruntwork-io/kubergrunt) executable is installed
+before running `kubergrunt --version`. 
+
+
+
+
+## How do you run these examples?
+
+1. Install [Terraform](https://www.terraform.io/).
+1. `terraform init`.
+1. `terraform apply`.
+
+
+

--- a/examples/executable-dependency/README.md
+++ b/examples/executable-dependency/README.md
@@ -8,6 +8,8 @@ The executable to run, the args to pass to it, and the download URL are all conf
 values show an example of ensuring the [kubergrunt](https://github.com/gruntwork-io/kubergrunt) executable is installed
 before running `kubergrunt --version`. 
 
+**NOTE**: This module requires that Python is installed on your system. It should work with Python 2 or 3.
+
 
 
 

--- a/examples/executable-dependency/main.tf
+++ b/examples/executable-dependency/main.tf
@@ -11,6 +11,7 @@ module "executable" {
   executable     = var.executable
   download_url   = var.download_url
   append_os_arch = var.append_os_arch
+  enabled        = var.enabled
 }
 
 # We run the executable here, with the specified args, and write the output to stdout in the form of JSON, as that's

--- a/examples/executable-dependency/main.tf
+++ b/examples/executable-dependency/main.tf
@@ -2,21 +2,21 @@ terraform {
   required_version = ">= 0.12"
 }
 
-module "kubergrunt" {
+module "executable" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
   # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/executable-dependency?ref=v1.0.8"
   source = "../../modules/executable-dependency"
 
-  executable     = "kubergrunt"
-  download_url   = "https://github.com/gruntwork-io/kubergrunt/releases/download/v0.5.13/kubergrunt"
-  append_os_arch = true
+  executable     = var.executable
+  download_url   = var.download_url
+  append_os_arch = var.append_os_arch
 }
 
-data "external" "kubergrunt_version" {
+data "external" "output" {
   program = [
     "bash",
     "-c",
-    "echo \"{\\\"version\\\": \\\"$(${module.kubergrunt.executable_path} --version)\\\"}\"",
+    "echo \"{\\\"output\\\": \\\"$(${module.executable.executable_path} ${var.executable_args})\\\"}\"",
   ]
 }

--- a/examples/executable-dependency/main.tf
+++ b/examples/executable-dependency/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+module "kubergrunt" {
+  # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/executable-dependency?ref=v1.0.8"
+  source = "../../modules/executable-dependency"
+
+  executable     = "kubergrunt"
+  download_url   = "https://github.com/gruntwork-io/kubergrunt/releases/download/v0.5.13/kubergrunt"
+  append_os_arch = true
+}
+
+data "external" "kubergrunt_version" {
+  program = [
+    "bash",
+    "-c",
+    "echo \"{\\\"version\\\": \\\"$(${module.kubergrunt.executable_path} --version)\\\"}\"",
+  ]
+}

--- a/examples/executable-dependency/main.tf
+++ b/examples/executable-dependency/main.tf
@@ -13,6 +13,8 @@ module "executable" {
   append_os_arch = var.append_os_arch
 }
 
+# We run the executable here, with the specified args, and write the output to stdout in the form of JSON, as that's
+# what the Terraform external data source requires to be able to read and parse that output.
 data "external" "output" {
   program = [
     "bash",

--- a/examples/executable-dependency/outputs.tf
+++ b/examples/executable-dependency/outputs.tf
@@ -1,0 +1,3 @@
+output "kubergrunt_version" {
+  value = data.external.kubergrunt_version.result.version
+}

--- a/examples/executable-dependency/outputs.tf
+++ b/examples/executable-dependency/outputs.tf
@@ -1,3 +1,3 @@
-output "kubergrunt_version" {
-  value = data.external.kubergrunt_version.result.version
+output "output" {
+  value = data.external.output.result.output
 }

--- a/examples/executable-dependency/variables.tf
+++ b/examples/executable-dependency/variables.tf
@@ -1,0 +1,19 @@
+variable "executable" {
+  type        = string
+  description = "The executable to look for on the system PATH and in var.install_dir. If not found, this executable will be downloaded from var.download_url."
+}
+
+variable "download_url" {
+  type        = string
+  description = "The URL to download the executable from if var.executable is not found on the system PATH or in var.install_dir."
+}
+
+variable "executable_args" {
+  type        = string
+  description = "The CLI args to pass when running the executable."
+}
+
+variable "append_os_arch" {
+  type        = bool
+  description = "If set to true, append the operating system and architecture to the URL. E.g., Append linux_amd64 if this code is being run on a 64 bit Linux OS."
+}

--- a/examples/executable-dependency/variables.tf
+++ b/examples/executable-dependency/variables.tf
@@ -1,19 +1,23 @@
 variable "executable" {
   type        = string
   description = "The executable to look for on the system PATH and in var.install_dir. If not found, this executable will be downloaded from var.download_url."
+  default     = "kubergrunt"
 }
 
 variable "download_url" {
   type        = string
   description = "The URL to download the executable from if var.executable is not found on the system PATH or in var.install_dir."
+  default     = "https://github.com/gruntwork-io/kubergrunt/releases/download/%s/kubergrunt"
 }
 
 variable "executable_args" {
   type        = string
   description = "The CLI args to pass when running the executable."
+  default     = "--version"
 }
 
 variable "append_os_arch" {
   type        = bool
   description = "If set to true, append the operating system and architecture to the URL. E.g., Append linux_amd64 if this code is being run on a 64 bit Linux OS."
+  default     = true
 }

--- a/examples/executable-dependency/variables.tf
+++ b/examples/executable-dependency/variables.tf
@@ -21,3 +21,9 @@ variable "append_os_arch" {
   description = "If set to true, append the operating system and architecture to the URL. E.g., Append linux_amd64 if this code is being run on a 64 bit Linux OS."
   default     = true
 }
+
+variable "enabled" {
+  description = "Set to false to have disable this module, so it does not try to download the executable, and always returns its path unchanged. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if this module should run or not."
+  type        = bool
+  default     = true
+}

--- a/modules/executable-dependency/README.md
+++ b/modules/executable-dependency/README.md
@@ -6,6 +6,8 @@ if it's not installed already: e.g., [terraform-aws-eks](https://github.com/grun
 [kubergrunt](https://github.com/gruntwork-io/kubergrunt) binary to be installed, and `executable-dependency` allows
 `terraform-aws-eks` to automatically download `kubergrunt` if it's not already available. 
 
+**NOTE**: This module requires that Python is installed on your system. It should work with Python 2 or 3.
+
 
 
 

--- a/modules/executable-dependency/README.md
+++ b/modules/executable-dependency/README.md
@@ -1,0 +1,51 @@
+# Executable Dependency
+
+This is a module that can be used to check if an executable is already installed, and if it's not, download it from a
+URL. This is useful if your Terraform code has an external dependency and you want that dependency to be auto installed
+if it's not installed already: e.g., [terraform-aws-eks](https://github.com/gruntwork-io/terraform-aws-eks) expects the 
+[kubergrunt](https://github.com/gruntwork-io/kubergrunt) binary to be installed, and `executable-dependency` allows
+`terraform-aws-eks` to automatically download `kubergrunt` if it's not already available. 
+
+
+
+
+## Example code
+
+See the [executable-dependency example](/examples/executable-dependency) for working sample code.
+
+
+
+
+## Usage
+
+Use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
+page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+
+```hcl
+module "path" {
+  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/join-path?ref=<VERSION>"
+  
+  executable     = "kubergrunt"
+  download_url   = "https://github.com/gruntwork-io/kubergrunt/releases/download/v0.5.13/kubergrunt"
+  append_os_arch = true
+}
+```
+
+The arguments to pass are:
+
+* `executable`: The executable to look for on the system `PATH` and in `install_dir`. If not found, this executable 
+  will be downloaded from `download_url`.
+  
+* `download_url`: The URL to download the executable from if `executable` is not found on the system `PATH` or 
+  `install_dir`.
+
+* `append_os_arch`: If set to true, append the operating system and architecture to the URL. E.g., Append `linux_amd64` 
+  if this code is being run on a 64 bit Linux OS. This is useful to download the proper binary (specifically, a binary
+  using the Go naming conventions) for the current operating system and CPU.
+
+* `install_dir`: The folder to copy the executable to after downloading it from `download_url`. If set to `null` (the 
+  default), the executable will be copied to a folder in the system temp directory. The folder will be named based on 
+  an md5 hash of `download_url`, so for each `download_url`, the executable will only have to be downloaded once.
+
+This module has a single output, `executable_path`, which is the path you should use to run the executable. The value
+will either be the path of the executable on the system `PATH` or a path in `install_dir`.

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -105,6 +105,7 @@ def get_os():
 def get_arch():
     arch = platform.machine().lower()
 
+    # Use the same architecture format as gox / go build, as that's what most Gruntwork binaries are built with
     if "64" in arch:
         return "amd64"
     if "386" in arch:

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -20,7 +20,7 @@ try:
     # Try the Python 3 import
     from urllib.request import urlretrieve
 except ImportError:
-    # Fall back to the Python 2 immport
+    # Fall back to the Python 2 import
     from urllib import urlretrieve
 
 

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# A script to check if an executable is installed, and if not, download it. In either case, returns the path to the
+# executable. This script is meant to be executed from a Terraform external data source. To be as portable as possible,
+# this script has no external dependencies (i.e., nothing that doesn't come with Python), and should work with both
+# Python 2 and 3.
+
+
+import sys
+import distutils.spawn
+import json
+import tempfile
+import os
+import os.path
+import hashlib
+import platform
+import logging
+import errno
+
+try:
+    # Try the Python 3 import
+    from urllib.request import urlretrieve
+except ImportError:
+    # Fall back to the Python 2 immport
+    from urllib import urlretrieve
+
+
+DEFAULT_INSTALL_DIR_NAME = "download-dependency-if-necessary"
+
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+log = logging.getLogger(__name__)
+
+
+def main():
+    if len(sys.argv) != 5:
+        raise Exception("Usage: download-dependency-if-necessary.py EXECUTABLE DOWNLOAD_URL INSTALL_DIR APPEND_OS_ARCH")
+
+    _, executable, download_url, install_dir, append_os_arch_raw = sys.argv
+    append_os_arch = append_os_arch_raw.lower() == "true"
+
+    if not install_dir:
+        install_dir = default_install_dir(download_url)
+    executable_install_dir_path = os.path.join(install_dir, executable)
+
+    # First, check if the executable is on the system PATH
+    executable_path = distutils.spawn.find_executable(executable)
+
+    # If it's not on the system PATH, check if it's in the install dir passed in by the user
+    if not executable_path and os.path.isfile(executable_install_dir_path):
+        executable_path = executable_install_dir_path
+
+    # If it's not there either, download the executable to the install dir
+    if not executable_path:
+        executable_path = download_executable(executable, download_url, install_dir, append_os_arch)
+
+    # Print the executable path to stdout as JSON so the Terraform external data source can read it in
+    result = {'path': executable_path}
+    print(json.dumps(result))
+
+
+def default_install_dir(download_url):
+    # Use a URL hash so that if the URL changes (e.g., because the version of the executable changed), we get a
+    # different local download folder, but if the URL stayed the same, we get the same folder, and don't have to
+    # re-download it.
+    url_hash = hashlib.md5(download_url.encode('utf-8')).hexdigest()
+    return os.path.join(tempfile.gettempdir(), DEFAULT_INSTALL_DIR_NAME, url_hash)
+
+
+def download_executable(executable, download_url, install_dir, append_os_arch):
+    if append_os_arch:
+        # Use the old string formatting style so that it works with Python 2
+        download_url = '%s_%s_%s' % (download_url, get_os(), get_arch())
+
+    executable_path = os.path.join(install_dir, executable)
+
+    log.info('Downloading from %s to %s' % (download_url, executable_path))
+
+    # Make sure all the parent folders exist
+    mkdir_p(install_dir)
+
+    # Download the executable
+    urlretrieve(download_url, executable_path)
+    
+    # Give the current user execute permissions
+    os.chmod(executable_path, 744)
+    
+    return executable_path
+
+
+def mkdir_p(path):
+    # For compatibility with Python 2
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+def get_os():
+    return platform.system().lower()
+
+
+def get_arch():
+    arch = platform.machine().lower()
+
+    if "64" in arch:
+        return "amd64"
+    if "386" in arch:
+        return "386"
+    if "arm" in arch:
+        return "arm"
+
+    return arch
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -24,7 +24,7 @@ except ImportError:
     from urllib import urlretrieve
 
 
-DEFAULT_INSTALL_DIR_NAME = "download-dependency-if-necessary"
+DEFAULT_INSTALL_DIR_NAME = 'download-dependency-if-necessary'
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -33,12 +33,12 @@ log = logging.getLogger(__name__)
 
 def main():
     if len(sys.argv) != 5:
-        raise Exception("Usage: download-dependency-if-necessary.py EXECUTABLE DOWNLOAD_URL INSTALL_DIR APPEND_OS_ARCH")
+        raise Exception('Usage: download-dependency-if-necessary.py EXECUTABLE DOWNLOAD_URL INSTALL_DIR APPEND_OS_ARCH')
 
     _, executable, download_url, install_dir, append_os_arch_raw = sys.argv
-    append_os_arch = append_os_arch_raw.lower() == "true"
+    append_os_arch = append_os_arch_raw.lower() == 'true'
 
-    if not install_dir or install_dir == "__NONE__":
+    if not install_dir or install_dir == '__NONE__':
         install_dir = default_install_dir(download_url)
     executable_install_dir_path = os.path.join(install_dir, executable)
 
@@ -69,11 +69,11 @@ def default_install_dir(download_url):
 def download_executable(executable, download_url, install_dir, append_os_arch):
     if append_os_arch:
         # Use the old string formatting style so that it works with Python 2
-        download_url = '%s_%s_%s' % (download_url, get_os(), get_arch())
+        download_url = '{}_{}_{}'.format(download_url, get_os(), get_arch())
 
     executable_path = os.path.join(install_dir, executable)
 
-    log.info('Downloading from %s to %s' % (download_url, executable_path))
+    log.info('Downloading from {} to {}'.format(download_url, executable_path))
 
     # Make sure all the parent folders exist
     mkdir_p(install_dir)
@@ -106,15 +106,15 @@ def get_arch():
     arch = platform.machine().lower()
 
     # Use the same architecture format as gox / go build, as that's what most Gruntwork binaries are built with
-    if "64" in arch:
-        return "amd64"
-    if "386" in arch:
-        return "386"
-    if "arm" in arch:
-        return "arm"
+    if '64' in arch:
+        return 'amd64'
+    if '386' in arch:
+        return '386'
+    if 'arm' in arch:
+        return 'arm'
 
     return arch
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -38,7 +38,7 @@ def main():
     _, executable, download_url, install_dir, append_os_arch_raw = sys.argv
     append_os_arch = append_os_arch_raw.lower() == "true"
 
-    if not install_dir:
+    if not install_dir or install_dir == "__NONE__":
         install_dir = default_install_dir(download_url)
     executable_install_dir_path = os.path.join(install_dir, executable)
 

--- a/modules/executable-dependency/main.tf
+++ b/modules/executable-dependency/main.tf
@@ -1,0 +1,9 @@
+data "external" "executable" {
+  program = [
+    "${path.module}/download-dependency-if-necessary.py",
+    var.executable,
+    var.download_url,
+    var.install_dir ==  null ? "/tmp" : var.install_dir,
+    var.append_os_arch ? "true" : "false"
+  ]
+}

--- a/modules/executable-dependency/main.tf
+++ b/modules/executable-dependency/main.tf
@@ -3,7 +3,9 @@ data "external" "executable" {
     "${path.module}/download-dependency-if-necessary.py",
     var.executable,
     var.download_url,
-    var.install_dir ==  null ? "/tmp" : var.install_dir,
+    # I wanted to use empty string here if var.install_dir was null, but Terraform's external data source gives you a
+    # weird error for empty strings, so we use a __NONE__ placeholder instead.
+    var.install_dir ==  null ? "__NONE__" : var.install_dir,
     var.append_os_arch ? "true" : "false"
   ]
 }

--- a/modules/executable-dependency/main.tf
+++ b/modules/executable-dependency/main.tf
@@ -1,11 +1,13 @@
 data "external" "executable" {
-  program = [
-    "${path.module}/download-dependency-if-necessary.py",
-    var.executable,
-    var.download_url,
-    # I wanted to use empty string here if var.install_dir was null, but Terraform's external data source gives you a
-    # weird error for empty strings, so we use a __NONE__ placeholder instead.
-    var.install_dir ==  null ? "__NONE__" : var.install_dir,
-    var.append_os_arch ? "true" : "false"
-  ]
+  program = concat(
+    [
+      "${path.module}/download-dependency-if-necessary.py",
+      "--executable",
+      var.executable,
+      "--download-url",
+      var.download_url
+    ],
+    var.install_dir != null ? ["--install-dir", var.install_dir] : [],
+    var.append_os_arch ? ["--append-os-arch"] : []
+  )
 }

--- a/modules/executable-dependency/main.tf
+++ b/modules/executable-dependency/main.tf
@@ -1,6 +1,7 @@
 data "external" "executable" {
   program = concat(
     [
+      "python",
       "${path.module}/download-dependency-if-necessary.py",
       "--executable",
       var.executable,

--- a/modules/executable-dependency/main.tf
+++ b/modules/executable-dependency/main.tf
@@ -1,4 +1,6 @@
 data "external" "executable" {
+  count = var.enabled ? 1 : 0
+
   program = concat(
     [
       "python",

--- a/modules/executable-dependency/outputs.tf
+++ b/modules/executable-dependency/outputs.tf
@@ -1,4 +1,4 @@
 output "executable_path" {
-  value       = data.external.executable.result.path
+  value       = var.enabled ? data.external.executable.0.result.path : var.executable
   description = "The path to use to run the executable. Will either be the path of the executable on the system PATH or a path in var.install_dir."
 }

--- a/modules/executable-dependency/outputs.tf
+++ b/modules/executable-dependency/outputs.tf
@@ -1,0 +1,4 @@
+output "executable_path" {
+  value       = data.external.executable.result.path
+  description = "The path to use to run the executable. Will either be the path of the executable on the system PATH or a path in var.install_dir."
+}

--- a/modules/executable-dependency/variables.tf
+++ b/modules/executable-dependency/variables.tf
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED MODULE PARAMETERS
+# These variables must be passed in by the operator.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "executable" {
+  type        = string
+  description = "The executable to look for on the system PATH and in var.install_dir. If not found, this executable will be downloaded from var.download_url."
+}
+
+variable "download_url" {
+  type        = string
+  description = "The URL to download the executable from if var.executable is not found on the system PATH or in var.install_dir."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL MODULE PARAMETERS
+# These variables have reasonable defaults, but may  be overridden if necessary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "append_os_arch" {
+  type        = bool
+  description = "If set to true, append the operating system and architecture to the URL. E.g., Append linux_amd64 if this code is being run on a 64 bit Linux OS."
+  default     = true
+}
+
+variable "install_dir" {
+  type        = string
+  description = "The folder to copy the executable to after download it from var.download_url. If set to null (the default), the executable will be copied to a folder in the system temp directory."
+  default     = null
+}

--- a/modules/executable-dependency/variables.tf
+++ b/modules/executable-dependency/variables.tf
@@ -26,6 +26,6 @@ variable "append_os_arch" {
 
 variable "install_dir" {
   type        = string
-  description = "The folder to copy the executable to after download it from var.download_url. If set to null (the default), the executable will be copied to a folder in the system temp directory."
+  description = "The folder to copy the executable to after downloading it from var.download_url. If set to null (the default), the executable will be copied to a folder in the system temp directory. The folder will be named based on an md5 hash of var.download_url, so for each var.download_url, the executable will only have to be downloaded once."
   default     = null
 }

--- a/modules/executable-dependency/variables.tf
+++ b/modules/executable-dependency/variables.tf
@@ -29,3 +29,9 @@ variable "install_dir" {
   description = "The folder to copy the executable to after downloading it from var.download_url. If set to null (the default), the executable will be copied to a folder in the system temp directory. The folder will be named based on an md5 hash of var.download_url, so for each var.download_url, the executable will only have to be downloaded once."
   default     = null
 }
+
+variable "enabled" {
+  description = "Set to false to have disable this module, so it does not try to download the executable, and always returns its path unchanged. This weird parameter exists solely because Terraform does not support conditional modules. Therefore, this is a hack to allow you to conditionally decide if this module should run or not."
+  type        = bool
+  default     = true
+}

--- a/test/executable_dependency_test.go
+++ b/test/executable_dependency_test.go
@@ -1,16 +1,29 @@
 package test
 
 import (
+	"fmt"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
-func TestExecutableDependency(t *testing.T) {
+// Make sure we can successfully download (if it's not installed already) and execute Kubergrunt
+func TestExecutableDependencyKubergrunt(t *testing.T) {
 	t.Parallel()
 
+	terraformDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/executable-dependency")
+
+	kubergrunt_version := "v0.5.13"
+
 	terraformOptions := &terraform.Options{
-		TerraformDir: "../examples/executable-dependency",
+		TerraformDir: terraformDir,
+		Vars: map[string]interface{}{
+			"executable":      "kubergrunt",
+			"download_url":    fmt.Sprintf("https://github.com/gruntwork-io/kubergrunt/releases/download/%s/kubergrunt", kubergrunt_version),
+			"executable_args": "--version",
+			"append_os_arch":  true,
+		},
 	}
 
 	defer terraform.Destroy(t, terraformOptions)
@@ -19,11 +32,43 @@ func TestExecutableDependency(t *testing.T) {
 
 	// Run apply the first time and make sure we get the expected output
 	terraform.Apply(t, terraformOptions)
-	version := terraform.OutputRequired(t, terraformOptions, "kubergrunt_version")
-	require.Equal(t, "kubergrunt version v0.5.13", version)
+	version := terraform.OutputRequired(t, terraformOptions, "output")
+	require.Equal(t, fmt.Sprintf("kubergrunt version %s", kubergrunt_version), version)
 
 	// Run apply once again to make sure the download code doesn't have issues with re-runs
 	terraform.Apply(t, terraformOptions)
-	version = terraform.OutputRequired(t, terraformOptions, "kubergrunt_version")
-	require.Equal(t, "kubergrunt version v0.5.13", version)
+	version = terraform.OutputRequired(t, terraformOptions, "output")
+	require.Equal(t, fmt.Sprintf("kubergrunt version %s", kubergrunt_version), version)
+}
+
+// Make sure we can successfully use an existing executable. In this case, we use Go, as you must have Go installed
+// already if you're running these tests!
+func TestExecutableDependencyGoLang(t *testing.T) {
+	t.Parallel()
+
+	terraformDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/executable-dependency")
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: terraformDir,
+		Vars: map[string]interface{}{
+			"executable":      "go",
+			"download_url":    "this is an intentionally fake URL as we expect Go to already be installed, so the code should NOT try to download anything",
+			"executable_args": "version",
+			"append_os_arch":  false,
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.Init(t, terraformOptions)
+
+	// Run apply the first time and make sure we get the expected output
+	terraform.Apply(t, terraformOptions)
+	version := terraform.OutputRequired(t, terraformOptions, "output")
+	require.Contains(t, version, "go version")
+
+	// Run apply once again to make sure the download code doesn't have issues with re-runs
+	terraform.Apply(t, terraformOptions)
+	version = terraform.OutputRequired(t, terraformOptions, "output")
+	require.Contains(t, version, "go version")
 }

--- a/test/executable_dependency_test.go
+++ b/test/executable_dependency_test.go
@@ -1,0 +1,29 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestExecutableDependency(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/executable-dependency",
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.Init(t, terraformOptions)
+
+	// Run apply the first time and make sure we get the expected output
+	terraform.Apply(t, terraformOptions)
+	version := terraform.OutputRequired(t, terraformOptions, "kubergrunt_version")
+	require.Equal(t, "kubergrunt version v0.5.13", version)
+
+	// Run apply once again to make sure the download code doesn't have issues with re-runs
+	terraform.Apply(t, terraformOptions)
+	version = terraform.OutputRequired(t, terraformOptions, "kubergrunt_version")
+	require.Equal(t, "kubergrunt version v0.5.13", version)
+}


### PR DESCRIPTION
@bwhaley and I were checking to see if the IaC Lib was compatible with TFC / TFE yesterday, and just about everything is. The only gotcha were modules that had external dependencies, such as `terraform-aws-eks`, which depends on `kubergrunt`. We then had an idea: what if we added a module that could download and install (at least some of) those dependencies if they weren't installed already?

This PR adds a new `executable-dependency` module that does just that. It checks the system `PATH`, and if the executable you want isn't installed already, it downloads it from a configurable URL, and returns the path to that. We could update `terraform-aws-eks` to use this module to automatically download `kubergrunt` (by default into a tmp dir) if it isn't already on the OS. I believe this will work fine in TFC / TFE too, as under the hood, they are running an Ubuntu VM, so we should be able to download the Kubergrunt binary for Linux. It's a bit of a hack, of course, but better than the module simply not working! 

There are, of course, limitations here: e.g., this code, as written, won't work with private dependencies that require auth, or those that require fancy install steps... But for a basic, open source binary like Kubergrunt, this seems like a quick win.