### PR TITLE
Add instance-type module to help deal with t2.micro / t3.micro issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.3"
             gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "v0.13.20"
-            configure-environment-for-gruntwork-module --circle-ci-2 --use-go-dep --go-src-path test --terragrunt-version NONE --terraform-version 0.12.0
+            configure-environment-for-gruntwork-module --circle-ci-2 --use-go-dep --go-src-path test --terragrunt-version NONE --terraform-version 0.12.28
 
       - run:
           name: run tests (with python2)

--- a/examples/instance-type/README.md
+++ b/examples/instance-type/README.md
@@ -1,0 +1,16 @@
+# Instance types example
+
+This folder shows examples of how to use the [instance-type module](/modules/instance-type) to pick an instance type
+that's available in all Availability Zones in the current AWS region.
+
+
+
+
+## How do you run these examples?
+
+1. Install [Terraform](https://www.terraform.io/).
+1. `terraform init`.
+1. `terraform apply`.
+
+
+

--- a/examples/instance-type/main.tf
+++ b/examples/instance-type/main.tf
@@ -1,0 +1,55 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# FIGURE OUT WHAT INSTANCE TYPE IS AVAILABLE IN ALL AZS IN THE CURRENT AWS REGION
+# ----------------------------------------------------------------------------------------------------------------------
+
+module "instance_types" {
+  source = "../../modules/instance-type"
+
+  instance_types = var.instance_types
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# USE THAT INSTANCE TYPE TO LAUNCH AN EC2 INSTANCE
+# ----------------------------------------------------------------------------------------------------------------------
+
+resource "aws_instance" "example" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = module.instance_types.recommended_instance_type
+
+  tags = {
+    Name = "instance-type-example"
+  }
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# FETCH THE ID OF AN UBUNTU AMI IN THE CURRENT REGION
+# ----------------------------------------------------------------------------------------------------------------------
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+}

--- a/examples/instance-type/outputs.tf
+++ b/examples/instance-type/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_type_map" {
+  description = "A map where the keys are the instance types in var.instance_types and the values are true or false, depending on whether every AZ in the current region contains this instance type."
+  value       = module.instance_types.instance_type_map
+}
+
+output "recommended_instance_type" {
+  description = "The recommended instance type to use in this AWS region. This will be the first instance type in var.instance_types which is available in all AZs in this region."
+  value       = module.instance_types.recommended_instance_type
+}

--- a/examples/instance-type/variables.tf
+++ b/examples/instance-type/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "The AWS region to run this code in"
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "instance_types" {
+  description = "A list of instance types to look up in the current AWS region."
+  type        = list(string)
+  default     = ["t3.micro", "t2.micro"]
+}

--- a/modules/instance-type/README.md
+++ b/modules/instance-type/README.md
@@ -1,0 +1,45 @@
+# Instance Type
+
+This is a module that can be used to look up a list of EC2 instance types and determine which of them is available in
+all Availability Zones (AZs) in the current AWS Region. This is useful because certain instance types, such as 
+`t2.micro` are not available in some of the newer AZs, while `t3.micro` is not available in some of the older AZs, and
+if you have code that needs to run on a "small" instance across all AZs in many different regions, you can use this
+module to automatically figure out which instance type you should use.
+
+
+
+
+
+## Example code
+
+See the [instance-type example](/examples/instance-type) for working sample code.
+
+
+
+
+## Usage
+
+Use the module in your Terraform code, replacing `<VERSION>` with the latest version from the [releases
+page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
+
+```hcl
+module "path" {
+  source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/instance-type?ref=<VERSION>"
+  
+  instance_types = ["t3.micro", "t2.micro"]
+}
+```
+
+The arguments to pass are:
+
+* `instance_types`: A list of instance types to look up in the current AWS region. We recommend putting them in order 
+  of preference, as the recommended_instance_type output variable will contain the first instance type from this list 
+  that is available in all AZs.
+
+When you run `apply`, the `recommended_instance_type` output variable will contain the recommended instance type to
+use. This will be the first instance type from your `instance_types` input that is available in all AZs in the current 
+region. If no instance type is available in all AZs, you'll get an error.
+
+For example, as of July, 2020, if you run `apply` on the code above in `eu-west-1`, the `recommended_instance_type` 
+will be `t3.micro`, as that's available in all AZs in `eu-west-1`. However, if you run the same code in 
+`ap-northeast-2`, the `recommended_instance_type` will be `t2.micro`, as `t3.micro` is only available in 2 of the 4 AZs.

--- a/modules/instance-type/README.md
+++ b/modules/instance-type/README.md
@@ -26,7 +26,7 @@ page](https://github.com/gruntwork-io/package-terraform-utilities/releases):
 module "path" {
   source = "git::git@github.com:gruntwork-io/package-terraform-utilities.git//modules/instance-type?ref=<VERSION>"
   
-  instance_types = ["t3.micro", "t2.micro"]
+  instance_types = ["t2.micro", "t3.micro"]
 }
 ```
 
@@ -41,5 +41,5 @@ use. This will be the first instance type from your `instance_types` input that 
 region. If no instance type is available in all AZs, you'll get an error.
 
 For example, as of July, 2020, if you run `apply` on the code above in `eu-west-1`, the `recommended_instance_type` 
-will be `t3.micro`, as that's available in all AZs in `eu-west-1`. However, if you run the same code in 
-`ap-northeast-2`, the `recommended_instance_type` will be `t2.micro`, as `t3.micro` is only available in 2 of the 4 AZs.
+will be `t2.micro`, as that's available in all AZs in `eu-west-1`. However, if you run the same code in 
+`ap-northeast-2`, the `recommended_instance_type` will be `t3.micro`, as `t2.micro` is only available in 2 of the 4 AZs.

--- a/modules/instance-type/main.tf
+++ b/modules/instance-type/main.tf
@@ -1,0 +1,19 @@
+data "aws_ec2_instance_type_offerings" "offerings" {
+  for_each = toset(data.aws_availability_zones.available.names)
+
+  filter {
+    name   = "instance-type"
+    values = var.instance_types
+  }
+
+  filter {
+    name = "location"
+    values = [each.key]
+  }
+
+  location_type = "availability-zone"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/modules/instance-type/outputs.tf
+++ b/modules/instance-type/outputs.tf
@@ -1,0 +1,17 @@
+locals {
+  instance_type_map = { for instance_type in var.instance_types : instance_type => (
+    ! contains([for az, offerings in data.aws_ec2_instance_type_offerings.offerings : contains(offerings.instance_types, instance_type)], false))
+  }
+
+  recommended_instance_type = [for instance_type in var.instance_types : instance_type if local.instance_type_map[instance_type]][0]
+}
+
+output "instance_type_map" {
+  description = "A map where the keys are the instance types in var.instance_types and the values are true or false, depending on whether every AZ in the current region contains this instance type."
+  value       = local.instance_type_map
+}
+
+output "recommended_instance_type" {
+  description = "The recommended instance type to use in this AWS region. This will be the first instance type in var.instance_types which is available in all AZs in this region."
+  value       = local.recommended_instance_type
+}

--- a/modules/instance-type/variables.tf
+++ b/modules/instance-type/variables.tf
@@ -1,0 +1,4 @@
+variable "instance_types" {
+  description = "A list of instance types to look up in the current AWS region. We recommend putting them in order of preference, as the recommended_instance_type output variable will contain the first instance type from this list that is available in all AZs."
+  type        = list(string)
+}

--- a/test/instance_type_test.go
+++ b/test/instance_type_test.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"testing"
+)
+
+func TestInstanceType(t *testing.T) {
+	t.Parallel()
+
+	awsRegion := aws.GetRandomRegion(t, nil, nil)
+
+	terratestOptions := &terraform.Options{
+		TerraformDir: "../examples/instance-type",
+		Vars: map[string]interface{}{
+			"aws_region": awsRegion,
+		},
+	}
+	defer terraform.Destroy(t, terratestOptions)
+
+	// We only need to run 'apply' for this test. If the instance launches successfully, it's because the code picked
+	// the right instance type to use for the current region (note: we pick the region at random).
+	terraform.InitAndApply(t, terratestOptions)
+}


### PR DESCRIPTION
This PR adds a new `instance-type` module to help us solve the issue where `t2.micro` and `t3.micro` instances are each available in some AZs, but not available in others. This module takes in a list of instance types to pick from and returns the recommended one to use, which is one that's available in all AZs in the current region.

Fixes https://github.com/gruntwork-io/usage-patterns/issues/395