### PR TITLE
Fix OS permissions in downloadable dependency

### DIFF
--- a/examples/executable-dependency/outputs.tf
+++ b/examples/executable-dependency/outputs.tf
@@ -1,3 +1,7 @@
 output "output" {
   value = data.external.output.result.output
 }
+
+output "downloaded_executable" {
+  value = module.executable.executable_path
+}

--- a/examples/executable-dependency/variables.tf
+++ b/examples/executable-dependency/variables.tf
@@ -7,7 +7,7 @@ variable "executable" {
 variable "download_url" {
   type        = string
   description = "The URL to download the executable from if var.executable is not found on the system PATH or in var.install_dir."
-  default     = "https://github.com/gruntwork-io/kubergrunt/releases/download/%s/kubergrunt"
+  default     = "https://github.com/gruntwork-io/kubergrunt/releases/download/v0.5.12/kubergrunt"
 }
 
 variable "executable_args" {

--- a/modules/executable-dependency/download-dependency-if-necessary.py
+++ b/modules/executable-dependency/download-dependency-if-necessary.py
@@ -87,10 +87,10 @@ def download_executable(executable, download_url, install_dir, append_os_arch):
 
     # Download the executable
     urlretrieve(download_url, executable_path)
-    
+
     # Give the current user execute permissions
-    os.chmod(executable_path, 744)
-    
+    os.chmod(executable_path, 0o744)
+
     return executable_path
 
 

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -655,11 +655,13 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/gruntwork-io/terratest/modules/aws",
     "github.com/gruntwork-io/terratest/modules/logger",
     "github.com/gruntwork-io/terratest/modules/random",
     "github.com/gruntwork-io/terratest/modules/terraform",
     "github.com/gruntwork-io/terratest/modules/test-structure",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
This fixes the OS permission being passed to `os.chmod`, which was raw int when we mean octet.